### PR TITLE
Allow customizing ntfy server and notification priority

### DIFF
--- a/Ntfynder/Configuration.cs
+++ b/Ntfynder/Configuration.cs
@@ -12,8 +12,12 @@ namespace Ntfy
         public bool EnableForDutyPops { get; set; } = true;
         public bool IgnoreAfkStatus { get; set; } = false;
 
+        // Optional: Specify a ntfy server location
+        public string NtfyServer { get; set; } = "https://ntfy.sh";
         // Optional: Specify the ntfy topic if needed
         public string NtfyTopic { get; set; } = "";
+        // Optional: Specify ntfy notification priority. Defaults to 5 (Max).
+        public int NtfyPriority { get; set; } = 5;
 
         [NonSerialized]
         private DalamudPluginInterface? PluginInterface;

--- a/Ntfynder/Delivery/NtfyDeliveryDelivery.cs
+++ b/Ntfynder/Delivery/NtfyDeliveryDelivery.cs
@@ -28,7 +28,6 @@ public static class NtfyDelivery
                 .WithHeaders(new
                 {
                     Priority = Plugin.Configuration.NtfyPriority,
-                    Host = "ntfy.sh"
                 })
                 .PostStringAsync(message);
         }

--- a/Ntfynder/Delivery/NtfyDeliveryDelivery.cs
+++ b/Ntfynder/Delivery/NtfyDeliveryDelivery.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Dalamud.Logging;
+using Flurl;
 using Flurl.Http;
 
 namespace Ntfy.Delivery;
@@ -14,7 +15,7 @@ public static class NtfyDelivery
     private static async Task DeliverAsync(string title, string text)
     {
         // Construct the URL dynamically using the NtfyTopic from the settings
-        var ntfyUrl = $"https://ntfy.sh/{Plugin.Configuration.NtfyTopic}";
+        var ntfyUrl = Plugin.Configuration.NtfyServer.AppendPathSegment(Plugin.Configuration.NtfyTopic);
 
         // Assuming `title` is used as the main message
         // Since ntfy doesn't have a separate title field, you can prepend it to the message or just send the message
@@ -26,7 +27,7 @@ public static class NtfyDelivery
             await ntfyUrl
                 .WithHeaders(new
                 {
-                    Priority = "5",
+                    Priority = Plugin.Configuration.NtfyPriority,
                     Host = "ntfy.sh"
                 })
                 .PostStringAsync(message);

--- a/Ntfynder/Ntfynder.csproj
+++ b/Ntfynder/Ntfynder.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <Platforms>x64</Platforms>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Ntfynder/Ntfynder.csproj
+++ b/Ntfynder/Ntfynder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Arcadia</Authors>
     <Company></Company>
-    <Version>1.1.2.0</Version>
+    <Version>1.1.3.0</Version>
     <Description>Check on your party while away from the computer.</Description>
     <Copyright>(C) 2024-2025</Copyright>
     <PackageProjectUrl>https://github.com/Arcadia64/Ntfynder</PackageProjectUrl>

--- a/Ntfynder/Windows/ConfigWindow.cs
+++ b/Ntfynder/Windows/ConfigWindow.cs
@@ -26,10 +26,43 @@ public class ConfigWindow : Window, IDisposable
     public override void Draw()
     {
         {
+            var cfg = Configuration.NtfyServer;
+            if (ImGui.InputText("Ntfy Server", ref cfg, 2048u))
+            {
+                Configuration.NtfyServer = cfg;
+            }
+        }
+        {
             var cfg = Configuration.NtfyTopic;
             if (ImGui.InputText("Ntfy Topic", ref cfg, 2048u))
             {
                 Configuration.NtfyTopic = cfg;
+            }
+        }
+        {
+            var cfg = Configuration.NtfyPriority;
+            string[] ntfyPriorityOptions = [
+                "5 (Max)",
+                "4 (High)",
+                "3 (Default)",
+                "2 (Low)",
+                "1 (Min)",
+            ];
+            var listBoxHeight = ImGui.GetTextLineHeightWithSpacing() * ntfyPriorityOptions.Length;
+            if (ImGui.BeginListBox("Ntfy Notification Priority", new Vector2(0, listBoxHeight)))
+            {
+                for (var i = 0; i < ntfyPriorityOptions.Length; i++)
+                {
+                    // Calculating the selected priority from ntfyPriorityOptions index. It's not
+                    // very elegant but ntfy's priority options seem stable enough that it should
+                    // not cause problems in the future.
+                    var currentPriority = ntfyPriorityOptions.Length - i;
+                    if (ImGui.Selectable(ntfyPriorityOptions[i], cfg == currentPriority))
+                    {
+                        Configuration.NtfyPriority = currentPriority;
+                    }
+                }
+                ImGui.EndListBox();
             }
         }
         {

--- a/Ntfynder/packages.lock.json
+++ b/Ntfynder/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",


### PR DESCRIPTION
I have added functionality to:
- specify a custom ntfy.sh server
- specify the priority of the notification being sent

I had to update .NET target to 8.0. Building was failing without it.